### PR TITLE
Avoid compile time warnings causing test failures due to undeclared $ENV variable

### DIFF
--- a/lib/Device/USB.pm
+++ b/lib/Device/USB.pm
@@ -5,6 +5,7 @@ use warnings;
 use strict;
 use Carp;
 
+no warnings; # Avoid compile time warnings from undeclared $ENV variables
 use Inline (
         C => "DATA",
         ($ENV{LIBUSB_LIBDIR}
@@ -18,6 +19,7 @@ use Inline (
    );
 
 Inline->init();
+use warnings;
 
 #
 # Now the Perl code.


### PR DESCRIPTION
Using Device::USB with undeclared LIBUSB_LIBDIR or LIBUSB_INCDIR gives a warning which causes compile tests to fail. to disable these warnings I wrapped the Inline code with a "no warnings;"
HTH