### PR TITLE
pass *FLAGS to compiler and linker for hardening

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Inline::MakeMaker;
+use Config;
 
 if($^O eq 'MSWin32')
 {
@@ -82,6 +83,8 @@ WriteMakefile(
     test               => {
         TESTS => 't/*.t xt/*.t',
     },
+    CCFLAGS => "$Config{ccflags} $ENV{CFLAGS} $ENV{CPPFLAGS}",
+    LDFLAGS => "$Config{lddlflags} $ENV{LDFLAGS}",
 );
 
 

--- a/lib/Device/USB.pm
+++ b/lib/Device/USB.pm
@@ -4,9 +4,12 @@ require 5.006;
 use warnings;
 use strict;
 use Carp;
+use Config;
 
 use Inline (
         C => "DATA",
+        CCFLAGS => "$Config{ccflags} $ENV{CFLAGS} $ENV{CPPFLAGS}",
+        LDDLFLAGS => "$Config{lddlflags} $ENV{LDFLAGS}",
         ($ENV{LIBUSB_LIBDIR}
             ? ( LIBS => "-L\"$ENV{LIBUSB_LIBDIR}\" " .
                         ($^O eq 'MSWin32' ? ' -llibusb -L\"$ENV{WINDDK}\\lib\\crt\\i386\" -lmsvcrt ' : '-lusb') )


### PR DESCRIPTION
Forwarding a patch to the Debian package by gregoa. This is necessary so that the standard hardening flags in Debian (-D_FORTIFY_SOURCE=2 -Wl,-z,relro etc.) can be passed to compiler and linker during package build.